### PR TITLE
Update getting-started.md  for "dotnet 9" users

### DIFF
--- a/site/docs/getting-started/v3/getting-started.md
+++ b/site/docs/getting-started/v3/getting-started.md
@@ -69,7 +69,7 @@ The generated project file should look something like this:
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <RootNamespace>MyFirstUnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <!--
     To enable the Microsoft Testing Platform 'dotnet test' experience, add property:
       <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>


### PR DESCRIPTION
The target framework created by the command `dotnet new xunit3` is incorrect for "dotnet 9" users. Following this tutorial should update their project file accordingly.