### PR TITLE
Update code xUnit v3 code coverage documentation with example

### DIFF
--- a/site/docs/getting-started/v3/code-coverage-with-mtp.md
+++ b/site/docs/getting-started/v3/code-coverage-with-mtp.md
@@ -182,6 +182,9 @@ $ dotnet run --project Tests -- -?
 
 Passing `--coverage` is the minimum requirement for enabling code coverage; the other three switches influence how the coverage information is reported.
 
+> [!NOTE]
+> The `--coverage-settings` is a path to the `.runsettings` file relative from your test project. Alternatively, you could use a full path to the `.runsettings` file. You could in example use it like: `dotnet run/test src/Foo.sln -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --coverage-settings ${{ github.workspace }}/src/.runsettings'`. You can use `dotnet run` or `dotnet test`.
+
 ## Generating code coverage XML
 
 ### Using `dotnet run`


### PR DESCRIPTION
This pull request updates the documentation to clarify how to use the `--coverage-settings` option when running tests with code coverage. It adds a helpful note explaining that the path to the .runsettings file can be relative or absolute, and provides an example command for both dotnet run and dotnet test.

Reason why I created this pull request is that I had trouble to figure out that the path is relatively from the test project and not the location from where your running in example `dotnet test`. 