### PR TITLE
Adding a note to getting-started about nested classes in simple filters

### DIFF
--- a/site/docs/getting-started/v3/getting-started.md
+++ b/site/docs/getting-started/v3/getting-started.md
@@ -477,6 +477,8 @@ A few notable things about running with `xunit-console`:
 
 * When running v3 test projects, they are run in a separate process. Like previous versions of `xunit.console`, it continues to run v1 and v2 test projects in the same process as the console runner (optionally in a separate AppDomain, if needed). Running them in a separate process does incur some overhead vs. running them directly, though in practice this should be fairly benign for most users.
 
+* When using the simple test filters, subclasses should be prefixed with `+` instead of `.`.  For example, running tests by class would be `-class "MyFirstUnitTests.UnitTest1+Nested"`.  The method equivalent would be `-method "MyFirstUnitTests.UnitTest1+Nested.Test2"`.
+
 * Result files from `xunit-console` contain run information for all tests assemblies in a single report. If you were run each v3 project individually and ask for a result file, it would only include information for that single test assembly.
 
 * Custom reporters are not available through `xunit-console`, as they are installed into the v3 test assembly's runner directly. If you are using a custom reporter, then you must directly run the test project.


### PR DESCRIPTION
Proposed fix for:
https://github.com/xunit/xunit/issues/1433